### PR TITLE
bugfix for service fee and increase startup wait for health check 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ LNBITS_DATA_FOLDER="./data"
 # LNBITS_DATABASE_URL="postgres://user:password@host:port/databasename"
 
 LNBITS_FORCE_HTTPS=false
-LNBITS_SERVICE_FEE="0.0"
+# LNBITS_SERVICE_FEE="0.0"
 # value in millisats
 LNBITS_RESERVE_FEE_MIN=2000
 # value in percent

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,4 @@ docker-images/aarch64.tar: Dockerfile docker_entrypoint.sh
 	docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) --platform=linux/arm64 --build-arg PLATFORM=arm64 -o type=docker,dest=docker-images/aarch64.tar .
 
 $(PKG_ID).s9pk: manifest.yaml instructions.md LICENSE icon.png scripts/embassy.js docker-images/aarch64.tar docker-images/x86_64.tar 
-	if ! [ -z "$(ARCH)" ]; then cp docker-images/$(ARCH).tar image.tar; fi
 	embassy-sdk pack

--- a/check-web.sh
+++ b/check-web.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DURATION=$(</dev/stdin)
-if (($DURATION <= 9000)); then
+if (($DURATION <= 25000)); then
     exit 60
 else
     if ! curl --silent --fail lnbits.embassy:5000 &>/dev/null; then

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -7,12 +7,10 @@ export CLN_PATH="/mnt/c-lightning/"
 export TOR_ADDRESS=$(yq e '.tor-address' /app/data/start9/config.yaml)
 export LAN_ADDRESS=$(yq e '.lan-address' /app/data/start9/config.yaml)
 export LNBITS_BACKEND_WALLET_CLASS=$(yq e '.wallet.type' /app/data/start9/config.yaml)
-export LNBITS_SERVICE_FEE=$(yq e '.service-fee' /app/data/start9/config.yaml)
 export FILE="/app/data/database.sqlite3"
 
 sed -i 's|LNBITS_ADMIN_USERS.*|LNBITS_ADMIN_USERS="'$LNBITS_USERNAME'"|' /app/.env
 sed -i 's|LNBITS_BACKEND_WALLET_CLASS=.*|LNBITS_BACKEND_WALLET_CLASS='$LNBITS_BACKEND_WALLET_CLASS'|' /app/.env
-sed -i 's|LNBITS_SERVICE_FEE=.*|LNBITS_SERVICE_FEE="'$LNBITS_SERVICE_FEE'"|' /app/.env
 
 if [ -f $FILE ] ; then {
     echo "Looking for existing accounts and wallets..."


### PR DESCRIPTION
On Fresh installs, LNBits will not start. Leftover code from the service fee needed to be removed. 
Also the health check was still timing out too quickly, so I bumped that up to 25000.