### PR TITLE
fix bug when switching between LN implementations

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,13 +2,8 @@ id: lnbits
 title: "LNBits"
 version: 0.10.10
 release-notes: |
-  * Code maintenance and dependency updates
-  * Enhanced favicon and admin notifications
-  * Improved lnurl handling and internal payment notifications
-  * Various testing and quality assurance enhancements
-  * Extended invoice expiry and wallet improvements
-  * Miscellaneous optimizations and version updates
-  * The list of all changes is available [here](https://github.com/lnbits/lnbits/compare/0.10.9...0.10.10).
+  * Update upstream to 0.10.10. Release notes available [here](https://github.com/lnbits/lnbits/compare/0.10.9...0.10.10).
+  * Fix bug when switching between LN implementations.
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/lnbits-wrapper"
 upstream-repo: "https://github.com/lnbits/lnbits"
@@ -83,7 +78,7 @@ interfaces:
       - http
 dependencies:
   lnd:
-    version: ">=0.14.3 <0.17.0"
+    version: ">=0.14.3 <0.18.0"
     description: Used to communicate with the Lightning Network.
     requirement:
       type: "opt-in"

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -25,6 +25,7 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "type": "enum",
     "name": "Lightning Implementation",
     "description": "The underlying Lightning implementation, currently LND or Core Lightning (CLN)",
+    "warning": "If you change the LN implementation after using LNBits this will delete all LNBits accounts and wallets related to the previously configured LN implementation! All LN funds will still be available on the underlying LN implementation.",
     "values": ["LndRestWallet", "CLightningWallet"],
     'value-names': {
       "LndRestWallet": "LND",


### PR DESCRIPTION
Fixes bug encountered when switching between LN implementations.

Previously when the configured LN implementation was changed after being used with the other implementation, the old LNBits users/data were persisted and the originally configured LN implementation would still be in use despite the Config and UI shown dependency.

With this fix the user is met with a warning when changing LN implementations as doing so will delete LNBits wallets/accounts associated with the previous LN implementation. Funds from the original LN implementation are SAFU on said LN implementation.