### PR TITLE
use LNBITS_ALLOWED_FUNDING_SOURCES and create/restore database backup when switching funding source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ LNBITS_BACKEND_WALLET_CLASS=LndRestWallet
 # VoidWallet is just a fallback that works without any actual Lightning capabilities,
 # just so you can see the UI before dealing with this file.
 
+# this will be set from docker_entrypoint.sh
+LNBITS_ALLOWED_FUNDING_SOURCES=""
+
 # Set one of these blocks depending on the wallet kind you chose above:
 
 # ClicheWallet


### PR DESCRIPTION
This PR adds two features:

1) Sets 'LNBITS_ALLOWED_FUNDING_SOURCES' to the currently configured funding source in StartOS. This makes it so that you cannot change the funding source from the LNBits admin UI. (preventing the deletion of the database when a user accidentally changes this)

2) When the funding source is changed (now only possible from the StartOS UI), it creates a backup of database.sqlite (suffixed with funding source name, e.g. database.sqlite.LndRestWallet).
It then checks if there is an existing backup of the new funding source (e.g. database.sqlite.CLightningWallet) and moves that backup back to 'database.sqlite'

This makes it so that you can switch between the two supported funding sources, while not losing any data.

If needed, I can split this PR in two, as I think 1 would be nice to have to prevent user errors. 2 is more opiniated.

I tested 1, which works perfectly.
I tested 2 so far that I can see that the mechanism works (backing up / restoring when switching between funding source). But I do not have a working CLN node that I can actually test with.