### PR TITLE
feat: set LNBITS_ALLOWED_FUNDING_SOURCES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ LNBITS_BACKEND_WALLET_CLASS=LndRestWallet
 # VoidWallet is just a fallback that works without any actual Lightning capabilities,
 # just so you can see the UI before dealing with this file.
 
+# this will be set from docker_entrypoint.sh
+LNBITS_ALLOWED_FUNDING_SOURCES=""
+
 # Set one of these blocks depending on the wallet kind you chose above:
 
 # ClicheWallet

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -17,6 +17,7 @@ export FILE="/app/data/database.sqlite3"
 MACAROON_HEADER=""
 
 sed -i 's|LNBITS_BACKEND_WALLET_CLASS=.*|LNBITS_BACKEND_WALLET_CLASS='$LNBITS_BACKEND_WALLET_CLASS'|' /app/.env
+sed -i 's|LNBITS_ALLOWED_FUNDING_SOURCES=.*|LNBITS_ALLOWED_FUNDING_SOURCES="'$LNBITS_BACKEND_WALLET_CLASS'"|' /app/.env
 
 if [ -f $FILE ]; then
     echo "Checking if underlying LN implementation has changed..."


### PR DESCRIPTION
 set LNBITS_ALLOWED_FUNDING_SOURCES to the configured funding source.

This prevents users from switching the funding source from the LNBits UI (which resulted in the deletion of the database without a warning).