### PR TITLE
chore: bump LNbits from 1.4.2 to 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lnbits/lnbits:v1.4.2 AS builder
+FROM lnbits/lnbits:v1.5.0 AS builder
 
 # arm64 or amd64
 ARG PLATFORM
@@ -6,7 +6,7 @@ ARG PLATFORM
 RUN apt-get update && apt-get install -y bash curl sqlite3 tini --no-install-recommends
 RUN curl -sS https://webi.sh/yq | sh
 
-FROM lnbits/lnbits:v1.4.2 AS final
+FROM lnbits/lnbits:v1.5.0 AS final
 
 COPY --from=builder /usr/bin/tini /usr/bin/tini
 COPY --from=builder /usr/bin/sqlite3 /usr/bin/sqlite3

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,9 +1,13 @@
 id: lnbits
 title: "LNBits"
-version: 1.4.2
+version: 1.5.0
 release-notes: |
-  * Update to v1.4.2 [release notes](https://github.com/lnbits/lnbits/releases/tag/v1.4.2)
-  * Bump max CLN version
+  * Update to v1.5.0 [release notes](https://github.com/lnbits/lnbits/releases/tag/v1.5.0)
+  * New: Spark L2 funding source, admin impersonate user, user activation workflow, invitation codes
+  * New: FIRST_INSTALL_TOKEN, optional exchange providers, persisted UI customization, modern theme
+  * Fixes: Timestamp timezone, validation errors, DB migration conflicts, rate limit select
+  * Security dependency bumps: cryptography, werkzeug, urllib3, aiohttp, axios, pillow
+  * Refactoring: Removed windowMixin, restructured settings, refactored payment check
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/lnbits-startos"
 upstream-repo: "https://github.com/lnbits/lnbits"


### PR DESCRIPTION
## Summary

- Bumps LNbits upstream Docker image from v1.4.2 to v1.5.0
- Updates `manifest.yaml` version and release notes

## Upstream Changes

[Full release notes](https://github.com/lnbits/lnbits/releases/tag/v1.5.0)

### New Features
- **Spark L2 funding source** — new Lightning funding backend
- **Admin impersonate user** — admins can act as any user for debugging/support
- **User activation workflow** — accounts require activation before use
- **Invitation codes** — invite-based onboarding for new users
- **FIRST_INSTALL_TOKEN** — secure initial setup token
- **Optional exchange providers** — configurable fiat exchange rate sources
- **Persisted UI customization** — theme/branding settings survive restarts
- **Modern theme** — refreshed UI look

### Fixes
- Timestamp timezone handling
- Validation errors
- DB migration conflicts
- Rate limit select

### Security
- Dependency bumps: cryptography, werkzeug, urllib3, aiohttp, axios, pillow

### Refactoring
- Removed windowMixin
- Restructured settings
- Refactored payment check

## Review Notes

This is a **minor** version bump with significant new features. Draft PR for human review before merging.

**Proposed new features to consider exposing in the StartOS wrapper:**
- User activation workflow and invitation codes could be surfaced in the package config
- Admin impersonation may need documentation in the instructions
- Spark L2 funding source could be added as a new dependency option if desired