### PR TITLE
chore: refresh sibling package git refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#132f3e72902ba899713b898b7534c479ccac7363",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.1",
         "diskusage": "^1.2.0"
@@ -220,7 +220,7 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0e166a059e2b1768abb6747b34780d52c160ad26",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0999634d379781c81cab3bd925416760905c5267",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.1",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -420,7 +420,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Routine maintenance pass.

- **LNbits**: already at the current upstream latest (v1.5.4).
- **start-sdk**: already at the current published latest (1.5.1).
- **`npm update`** advanced the pinned commits for sibling packages:
  - `bitcoin-core-startos`: `c745e4d` → `132f3e7`
  - `lnd-startos`: `0e166a0` → `0999634`

No `package.json`, manifest, Dockerfile, or version-file changes are required.

## Verification

- `npm run check` (tsc) — clean
- `make` — built `lnbits_aarch64.s9pk` successfully (`v1.5.4:0`, SDK 1.5.1)

## Test plan

- [x] `npm run check` passes
- [x] `make` produces a valid `.s9pk`