### PR TITLE
chore: bump start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "lnbits-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "cln-startos": "github:Start9Labs/cln-startos#next",
         "lnd-startos": "github:Start9Labs/lnd-startos#next"
       },
@@ -63,9 +63,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -110,16 +110,16 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#9149541bb06eb6a71addb00939b277e06fe8fb74",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#e0edea43e908f60ff5b43c0068d82b35372bf781",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1"
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0e166a059e2b1768abb6747b34780d52c160ad26",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#eff043e4c6662f35a3b0065e8836bacec04baf0f",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
@@ -420,7 +420,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "cln-startos": "github:Start9Labs/cln-startos#next",
     "lnd-startos": "github:Start9Labs/lnd-startos#next"
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_1_5_4_0 } from './v1.5.4.0'
+import { v_1_5_4_1 } from './v1.5.4.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_5_4_0,
+  current: v_1_5_4_1,
   other: [],
 })

--- a/startos/versions/v1.5.4.1.ts
+++ b/startos/versions/v1.5.4.1.ts
@@ -3,29 +3,14 @@ import { rm } from 'fs/promises'
 import { envFile } from '../fileModels/env'
 import { sdk } from '../sdk'
 
-export const v_1_5_4_0 = VersionInfo.of({
-  version: '1.5.4:0',
+export const v_1_5_4_1 = VersionInfo.of({
+  version: '1.5.4:1',
   releaseNotes: {
-    en_US: `**Bumps**
-
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    es_ES: `**Actualizaciones**
-
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    de_DE: `**Aktualisierungen**
-
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    pl_PL: `**Aktualizacje**
-
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    fr_FR: `**Mises à jour**
-
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
+    en_US: 'Bumps start-sdk to 1.5.2.',
+    es_ES: 'Actualiza start-sdk a 1.5.2.',
+    de_DE: 'Aktualisiert start-sdk auf 1.5.2.',
+    pl_PL: 'Aktualizuje start-sdk do 1.5.2.',
+    fr_FR: 'Met à jour start-sdk vers 1.5.2.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- `@start9labs/start-sdk` 1.5.1 → 1.5.2.
- Package version 1.5.4:0 → 1.5.4:1 (file renamed in place per packaging convention; no migration added).
- Release notes localized as a single-line note since this is a single-change release.

## SDK 1.5.2 notes

The only change in 1.5.2 is a fix to `Backups.withPgDump` / `Backups.withMysqlDump`. LNbits is sqlite-only and this package backs up via `sdk.Backups.ofVolumes('main')`, so the fix does not apply here — no code changes required to adopt it.

## Upstream

LNbits is already on the latest upstream release (v1.5.4); no upstream bump in this PR.

## Test plan

- [x] `make` builds a clean `.s9pk` (aarch64, 166M, SDK 1.5.2, version `1.5.4:1`).