### PR TITLE
fix: LNbits falls back to VoidWallet — re-apply StartOS-managed LN connection on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Settings **not** managed by StartOS (hardcoded):
 | `AUTH_ALLOWED_METHODS` | `username-password` | Only username/password auth |
 | `LNBITS_ALLOWED_FUNDING_SOURCES` | Matches selected backend | Restricted to configured implementation |
 
+> **Note on the Lightning backend connection:** With `LNBITS_ADMIN_UI=true`, LNbits persists its funding-source settings (endpoint, certificate, macaroon, CLN socket) in its own database and lets those override the `.env` on startup. Because these paths point at StartOS-mounted dependency volumes and are not user-configurable, a `sync-funding-settings` oneshot rewrites them in LNbits' database to match the `.env` on **every** start (see [`startos/syncFundingSettings.ts`](startos/syncFundingSettings.ts)). Editing the funding-source connection in the LNbits Admin UI therefore has no lasting effect — it is reset on the next restart. This also self-heals installs migrated from the legacy package, whose database still held the old `/mnt/lnd/admin.macaroon` path and silently fell back to VoidWallet.
+
 ## Network Access and Interfaces
 
 | Interface | Port | Protocol | Purpose |
@@ -150,6 +152,7 @@ LND files used: `tls.cert`, `data/chain/bitcoin/mainnet/admin.macaroon`. Core Li
 3. **Username/password auth only** — `AUTH_ALLOWED_METHODS` is set to `username-password`; other methods (e.g., Google OAuth) are not available
 4. **Switching backends deletes the database** — changing from LND to CLN (or vice versa) removes the existing LNbits database
 5. **Custom Docker image** — adds sqlite3 CLI, bcrypt, and other tools not in the upstream image
+6. **Lightning backend connection is StartOS-managed** — the endpoint, certificate, macaroon, and CLN socket are re-applied to LNbits' database on every start; editing them in the LNbits Admin UI does not persist across restarts
 
 ## What Is Unchanged from Upstream
 

--- a/instructions.md
+++ b/instructions.md
@@ -24,6 +24,8 @@ LNbits posts a critical task after install. You can't start the service until it
 
 Day-to-day use happens inside the LNbits Web UI: create wallets, share or invite users to them, send and receive Lightning payments, and install LNbits extensions from the built-in marketplace. The super user manages global settings and other accounts from LNbits' own **Admin UI**, reached from inside the Web UI once you're signed in as that account.
 
+> One exception: the **funding source connection** (the node endpoint, certificate, and macaroon under the Admin UI's "Funding" page) is managed by StartOS and re-applied every time the service starts. You don't need to set it, and any change you make there will revert on the next restart. Use the **Lightning Implementation** action to choose your backend instead.
+
 ### Actions
 
 - **Lightning Implementation** — switch the funding backend between LND and Core Lightning. **Changing the backend after LNbits has been used wipes the LNbits database**, removing every account and wallet stored on this instance. Funds on the underlying Lightning node are unaffected, but anything that lived only in LNbits (extension data, internal wallets, invoices) is gone. Only use this when you really mean to start over.
@@ -34,3 +36,4 @@ Day-to-day use happens inside the LNbits Web UI: create wallets, share or invite
 - **Only LND and Core Lightning are supported as funding backends.** Upstream LNbits ships many more (OpenNode, Eclair, LNPay, etc.); on StartOS the choice is restricted to the two Lightning nodes the platform packages.
 - **SQLite only.** Upstream supports PostgreSQL and CockroachDB as alternative databases; the StartOS package uses the embedded SQLite database and does not expose that switch.
 - **Username and password sign-in only.** Other LNbits auth methods (Google OAuth, etc.) are disabled in this package.
+- **The Lightning node connection is managed by StartOS.** The funding source endpoint, certificate, and macaroon are set for you to point at your installed LND or Core Lightning node and are re-applied on every start, so editing them in the LNbits Admin UI has no lasting effect.

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -3,6 +3,7 @@ import { manifest as lndManifest } from 'lnd-startos/startos/manifest'
 import { envFile } from './fileModels/env'
 import { i18n } from './i18n'
 import { sdk } from './sdk'
+import { syncFundingSettings } from './syncFundingSettings'
 import { clnMountpoint, lndMountpoint, mainMounts, uiPort } from './utils'
 
 export const main = sdk.setupMain(async ({ effects }) => {
@@ -50,18 +51,33 @@ export const main = sdk.setupMain(async ({ effects }) => {
    *
    * Each daemon defines its own health check, which can optionally be exposed to the user.
    */
-  return sdk.Daemons.of(effects).addDaemon('primary', {
-    subcontainer: lnbitsSub,
-    exec: { command: ['uv', 'run', 'lnbits'], env: env || {} },
-    ready: {
-      display: i18n('Web Interface'),
-      gracePeriod: 75_000,
-      fn: () =>
-        sdk.healthCheck.checkPortListening(effects, uiPort, {
-          successMessage: i18n('The web interface is ready'),
-          errorMessage: i18n('The web interface is not ready'),
-        }),
-    },
-    requires: [],
-  })
+  return sdk.Daemons.of(effects)
+    .addOneshot('sync-funding-settings', {
+      subcontainer: lnbitsSub,
+      // LNbits' Admin UI persists the backend connection settings in its own
+      // database and lets them override the `.env` on startup. Re-apply the
+      // StartOS-managed paths before LNbits starts so the configured node — not
+      // a stale/legacy value — is always used. See syncFundingSettings.ts.
+      exec: {
+        fn: async () => {
+          await syncFundingSettings(lnbitsSub, env)
+          return null
+        },
+      },
+      requires: [],
+    })
+    .addDaemon('primary', {
+      subcontainer: lnbitsSub,
+      exec: { command: ['uv', 'run', 'lnbits'], env: env || {} },
+      ready: {
+        display: i18n('Web Interface'),
+        gracePeriod: 75_000,
+        fn: () =>
+          sdk.healthCheck.checkPortListening(effects, uiPort, {
+            successMessage: i18n('The web interface is ready'),
+            errorMessage: i18n('The web interface is not ready'),
+          }),
+      },
+      requires: ['sync-funding-settings'],
+    })
 })

--- a/startos/syncFundingSettings.ts
+++ b/startos/syncFundingSettings.ts
@@ -1,0 +1,116 @@
+import { z } from '@start9labs/start-sdk'
+import { access } from 'fs/promises'
+import { shape } from './fileModels/env'
+import { sdk } from './sdk'
+import { db } from './utils'
+
+type Env = z.infer<typeof shape>
+
+// Minimal structural view of a SubContainer's exec surface, so this helper
+// doesn't depend on the full SubContainer generic.
+type ExecSub = {
+  execFail(
+    cmd: string[],
+    opts?: { env?: Record<string, string> },
+  ): Promise<{ stdout: string | Buffer }>
+}
+
+/**
+ * Force LNbits' stored Lightning-backend connection settings to match the
+ * StartOS-managed `.env`.
+ *
+ * With `LNBITS_ADMIN_UI=true`, LNbits persists its funding-source settings
+ * (endpoint, cert, macaroon, CLN rpc path) into its own SQLite database
+ * (`system_settings`, tag `core`). On every startup those DB values OVERRIDE
+ * the environment — see lnbits `check_admin_settings` -> `update_cached_settings`.
+ * On StartOS these paths are not user-configurable; they point at mounted
+ * dependency volumes, so the DB must always track the `.env`.
+ *
+ * Without this, an install carried over from the legacy (Embassy / StartOS
+ * 0.3.x) package keeps the old macaroon path `/mnt/lnd/admin.macaroon` in its
+ * database. That path no longer exists under StartOS 0.4.x (the macaroon now
+ * lives at `/mnt/lnd/data/chain/bitcoin/mainnet/admin.macaroon`), so LNbits
+ * fails to initialize the backend and silently falls back to VoidWallet.
+ *
+ * We OVERWRITE the rows rather than delete them: a missing row resolves to the
+ * field default (`None`) at startup, not the env value, because
+ * `check_admin_settings` feeds `settings_db.dict()` — every field, defaults
+ * included — to `update_cached_settings`. Values are JSON-encoded to match how
+ * LNbits reads them (`json.loads`).
+ *
+ * Idempotent; runs as a oneshot before the primary daemon.
+ */
+export async function syncFundingSettings(
+  subc: ExecSub,
+  env: Env | null,
+): Promise<void> {
+  if (!env) return
+
+  // Fresh install: LNbits hasn't created its database yet, so there is nothing
+  // to reconcile — it will seed `system_settings` from the `.env` on first
+  // start. Bail before touching the path so sqlite3 doesn't create a stray
+  // empty database on the volume.
+  try {
+    await access(sdk.volumes.main.subpath('database.sqlite3'))
+  } catch {
+    return
+  }
+
+  const upserts: Record<string, string> = {}
+  const deletes: string[] = []
+
+  if (env.LNBITS_BACKEND_WALLET_CLASS === 'LndRestWallet') {
+    upserts.lnd_rest_endpoint = env.LND_REST_ENDPOINT
+    upserts.lnd_rest_cert = env.LND_REST_CERT
+    upserts.lnd_rest_macaroon = env.LND_REST_MACAROON
+    // A stale encrypted macaroon would be tried alongside the plain path; clear
+    // it so only the StartOS-managed macaroon file is used.
+    deletes.push('lnd_rest_macaroon_encrypted')
+  } else if (env.LNBITS_BACKEND_WALLET_CLASS === 'CoreLightningWallet') {
+    // LNbits reads `corelightning_rpc` first, then `clightning_rpc`; set both.
+    upserts.corelightning_rpc = env.CLIGHTNING_RPC
+    upserts.clightning_rpc = env.CLIGHTNING_RPC
+  } else {
+    return
+  }
+
+  // Single-quote escape for SQL string literals (values are fixed mountpoint
+  // paths today, but keep this robust against future changes).
+  const sqlStr = (s: string) => `'${s.replace(/'/g, "''")}'`
+
+  const statements = [
+    ...Object.entries(upserts).map(
+      ([id, value]) =>
+        `INSERT INTO system_settings (id, value, tag) VALUES (${sqlStr(
+          id,
+        )}, ${sqlStr(JSON.stringify(value))}, 'core') ` +
+        `ON CONFLICT(id, tag) DO UPDATE SET value = excluded.value;`,
+    ),
+    ...deletes.map(
+      (id) =>
+        `DELETE FROM system_settings WHERE id = ${sqlStr(id)} AND tag = 'core';`,
+    ),
+  ].join(' ')
+
+  // Best-effort: this reconcile is an improvement, never a precondition for
+  // running. A sqlite failure (locked db, mid-init schema, fs error) must NOT
+  // block startup — that would be worse than the bug we're fixing. On failure
+  // we log and let LNbits start with whatever is already in its database (the
+  // status quo), so this change can only ever help, never regress boot.
+  try {
+    // The settings table may not exist yet if a previous start died mid-init.
+    const tableCheck = await subc.execFail([
+      'sqlite3',
+      db,
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='system_settings';",
+    ])
+    if (!tableCheck.stdout.toString().trim()) return
+
+    await subc.execFail(['sqlite3', db, statements])
+  } catch (e) {
+    console.error(
+      'sync-funding-settings: could not reconcile LNbits funding settings; starting anyway',
+      e,
+    )
+  }
+}

--- a/startos/syncFundingSettings.ts
+++ b/startos/syncFundingSettings.ts
@@ -20,7 +20,7 @@ type ExecSub = {
  * StartOS-managed `.env`.
  *
  * With `LNBITS_ADMIN_UI=true`, LNbits persists its funding-source settings
- * (endpoint, cert, macaroon, CLN rpc path) into its own SQLite database
+ * (backend class, endpoint, cert, macaroon, CLN rpc) into its own SQLite db
  * (`system_settings`, tag `core`). On every startup those DB values OVERRIDE
  * the environment — see lnbits `check_admin_settings` -> `update_cached_settings`.
  * On StartOS these paths are not user-configurable; they point at mounted
@@ -73,6 +73,12 @@ export async function syncFundingSettings(
   } else {
     return
   }
+
+  // The selected backend is itself editable (not a readonly setting), so a
+  // stale or admin-UI-edited `lnbits_backend_wallet_class` would override the
+  // env and could point LNbits at the unmounted node. Pin it too, so the whole
+  // funding configuration is StartOS-owned.
+  upserts.lnbits_backend_wallet_class = env.LNBITS_BACKEND_WALLET_CLASS
 
   // Single-quote escape for SQL string literals (values are fixed mountpoint
   // paths today, but keep this robust against future changes).

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,28 +4,23 @@ import { envFile } from '../fileModels/env'
 import { sdk } from '../sdk'
 
 export const current = VersionInfo.of({
-  version: '1.5.4:0',
+  version: '1.5.4:1',
   releaseNotes: {
-    en_US: `**Bumps**
+    en_US: `**Fixes**
 
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    es_ES: `**Actualizaciones**
+- Reconcile LNbits' saved Lightning backend connection (endpoint, certificate, macaroon / CLN socket) with the StartOS-managed configuration on every start. Fixes installs that fell back to VoidWallet because LNbits' database still pointed at a stale macaroon path.`,
+    es_ES: `**Correcciones**
 
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    de_DE: `**Aktualisierungen**
+- Reconcilia la conexión del backend Lightning guardada por LNbits (endpoint, certificado, macaroon / socket de CLN) con la configuración gestionada por StartOS en cada arranque. Soluciona las instalaciones que recurrían a VoidWallet porque la base de datos de LNbits apuntaba a una ruta de macaroon obsoleta.`,
+    de_DE: `**Korrekturen**
 
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    pl_PL: `**Aktualizacje**
+- Gleicht die von LNbits gespeicherte Lightning-Backend-Verbindung (Endpoint, Zertifikat, Macaroon / CLN-Socket) bei jedem Start mit der von StartOS verwalteten Konfiguration ab. Behebt Installationen, die auf VoidWallet zurückfielen, weil die LNbits-Datenbank noch auf einen veralteten Macaroon-Pfad verwies.`,
+    pl_PL: `**Poprawki**
 
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
-    fr_FR: `**Mises à jour**
+- Uzgadnia zapisane przez LNbits połączenie z backendem Lightning (endpoint, certyfikat, macaroon / gniazdo CLN) z konfiguracją zarządzaną przez StartOS przy każdym uruchomieniu. Naprawia instalacje, które przełączały się na VoidWallet, ponieważ baza danych LNbits wskazywała nieaktualną ścieżkę macaroon.`,
+    fr_FR: `**Corrections**
 
-- LNbits → 1.5.4
-- start-sdk → 1.5.0`,
+- Réaligne la connexion au backend Lightning enregistrée par LNbits (endpoint, certificat, macaroon / socket CLN) avec la configuration gérée par StartOS à chaque démarrage. Corrige les installations qui basculaient sur VoidWallet parce que la base de données de LNbits pointait encore vers un chemin de macaroon obsolète.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Problem

Reported on the community forum: [LNbits 1.5.4 falls back to VoidWallet on StartOS 0.4.0-beta.9](https://community.start9.com/t/lnbits-1-5-4-falls-back-to-voidwallet-on-startos-0-4-0-beta-9-lnd-admin-macaroon-not-mounted-mnt-lnd-admin-macaroon-missing-despite-dependency-showing-satisfied/5281). LNbits logs:

```
ERROR | Error initializing LndRestWallet: [Errno 2] No such file or directory: '/mnt/lnd/admin.macaroon'
WARNING | Fallback to VoidWallet, because the backend for LndRestWallet isn't working properly
```

The package configures `LND_REST_MACAROON=/mnt/lnd/data/chain/bitcoin/mainnet/admin.macaroon` (the correct 0.4.x path, and the file is present there), but LNbits looks at the bare `/mnt/lnd/admin.macaroon` — the path the **legacy Embassy / 0.3.x package** used.

## Root cause

This is **not** a mount bug. With `LNBITS_ADMIN_UI=true`, LNbits persists its funding-source settings (`lnd_rest_endpoint`, `lnd_rest_cert`, `lnd_rest_macaroon`, and CLN `corelightning_rpc`/`clightning_rpc`) as rows in its own SQLite `system_settings` table (tag `core`). On every startup, `check_admin_settings()` loads those rows and `update_cached_settings()` **overrides** the `.env` values with them — only `readonly_variables` are protected, and these funding fields are editable, not readonly.

Installs migrated from the legacy package still hold the old `/mnt/lnd/admin.macaroon` value in their database, so the corrected `.env` is ignored, the file isn't found, and LNbits falls back to VoidWallet. Re-running the **Lightning Implementation** action or reinstalling doesn't help — the `main` volume (and its `database.sqlite3`) persists across both.

## Fix

A `sync-funding-settings` oneshot runs before the primary daemon and rewrites the configured backend's connection rows in `system_settings` to match the `.env`.

Rows are **overwritten, not deleted**: a missing row resolves to the field default (`None`) at startup — not the env value — because `check_admin_settings` feeds `settings_db.dict()` (every field, defaults included) into `update_cached_settings`. Values are JSON-encoded to match LNbits' `json.loads` reads. The stale `lnd_rest_macaroon_encrypted` row, if any, is cleared so the plain macaroon path is used.

The oneshot is idempotent and self-heals affected installs on the next start. It also enforces the package's existing contract that the LN connection is StartOS-managed — `README.md`/`instructions.md` updated to note that editing it in the LNbits Admin UI has no lasting effect.

Package revision bumped to `1.5.4:1` (no upstream change). No migration is needed — the oneshot covers the upgrade case on next start.

## Testing

- `tsc --noEmit` — clean
- `npm run build` (ncc bundle) — clean
- `make x86` — builds `lnbits_x86_64.s9pk` (v1.5.4:1)
- ⚠️ Not yet device-tested against a migrated install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
